### PR TITLE
Prevent parsing nil data

### DIFF
--- a/GIFMetadata.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/GIFMetadata.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sources/GIFMetadata.swift
+++ b/Sources/GIFMetadata.swift
@@ -37,6 +37,11 @@ import Foundation
         super.init()
         self.data = data
         pointerIndex = 0
+
+        if data.count == 0 {
+            return
+        }
+
         readHeader()
         logicalScreenDescriptor = readLogicalScreenDescriptor()
         readGlobalColorTable()

--- a/Sources/GIFMetadata.swift
+++ b/Sources/GIFMetadata.swift
@@ -184,7 +184,7 @@ import Foundation
     }
     func readImageData(){
         //print("\(#function)")
-        let LZWMinimumCodeSize = readByte()
+        let _ = readByte() // LZWMinimumCodeSize
         pointerIndex? += 1
         while true {
             let byte = readByte()
@@ -241,7 +241,7 @@ import Foundation
         let applicationIdentifier = readBytes(8)
         let applicationIdentifierStr = String(bytes: applicationIdentifier, encoding: .utf8)
         pointerIndex? += 8
-        let applicationAuthenticationCode = readBytes(3)
+        let _ = readBytes(3) // applicationAuthenticationCode
         pointerIndex? += 3
 
         while true {
@@ -321,7 +321,7 @@ extension GIFMetadata /*: CustomStringConvertible*/ {
     override public var description: String {
         return [
             "<\(String(describing: type(of: self)))",
-            "logicalScreenDescriptor: \(logicalScreenDescriptor)",
+            "logicalScreenDescriptor: \(logicalScreenDescriptor as Optional)",
             "applicationExtensions: \(applicationExtensions)",
             "imageDescriptors: \(imageDescriptors)",
             "imageDataCount: \(imageDataCount)",

--- a/Tests/GIFMetadataTests/GIFMetadataTests.swift
+++ b/Tests/GIFMetadataTests/GIFMetadataTests.swift
@@ -47,6 +47,16 @@ class GIFMetadataTests: XCTestCase {
         }
     }
 
+    func testNilData() {
+        let nilGifData = Data(bytes: [])
+        let metadata = GIFMetadata(nilGifData)
+        //print("metadata = \(metadata)")
+        let expected = 0
+        let result = metadata.preferredLoopCount()
+        //print("result: \(result), expected: \(expected)")
+        XCTAssertEqual(result, expected, "nilGifData's preferredLoopCount() == \(result), expected == \(expected)")
+    }
+
     static var allTests = [
         ("testBasic", testBasic),
         ("testPreferedLoopCount", testPreferedLoopCount),


### PR DESCRIPTION
# Summary
Prevent parsing nil data.

# Tested patterns
I confirmed the test 'testNilData' passed.